### PR TITLE
Nissix plugin scope-packages on @wix/crash-dec-2018-store-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-i18next": "^7.11.0",
-    "wix-experiments-react": "^2.0.6",
+    "@wix/wix-experiments-react": "^2.0.6",
     "wix-style-react": "^5.18.2"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "puppeteer": "^1.1.0",
     "react-test-renderer": "~15.6.0",
     "wix-ui-test-utils": "^1.0.130",
-    "yoshi": "^3.0.0",
+    "@wix/yoshi": "^3.0.0",
     "yoshi-style-dependencies": "^3.0.0"
   },
   "lint-staged": {

--- a/src/client.js
+++ b/src/client.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { wixAxiosConfig } from '@wix/wix-axios-config';
 import i18n from './i18n';
 import App from './components/App';
-import { ExperimentsProvider } from 'wix-experiments-react';
+import { ExperimentsProvider } from '@wix/wix-experiments-react';
 
 const baseURL = window.__BASEURL__;
 const locale = window.__LOCALE__;

--- a/src/components/App/App.spec.js
+++ b/src/components/App/App.spec.js
@@ -5,7 +5,7 @@ import App from './App';
 import i18n from '../../../test/helpers/i18n.mock';
 import translation from '../../locales/messages_en';
 import i18next from 'i18next';
-import { ExperimentsProvider } from 'wix-experiments-react';
+import { ExperimentsProvider } from '@wix/wix-experiments-react';
 
 
 // jest.mock('../../apiServices');

--- a/src/components/ProductsList/ProductsList.js
+++ b/src/components/ProductsList/ProductsList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import { navigate } from '@reach/router';
-import { withExperiments } from 'wix-experiments-react';
+import { withExperiments } from '@wix/wix-experiments-react';
 import Table from 'wix-style-react/Table';
 import Button from 'wix-style-react/Button';
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-jest');
+module.exports = require('@wix/yoshi/config/wallaby-jest');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.061s



Output Log:
Migrating package "@wix/crash-dec-2018-store-8" in .


## Migration from non scope to @wix/scoped packages
> /tmp/e85de0ef4973f2f23c1bea1ea754bf69

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
src/client.js
src/components/App/App.spec.js
src/components/ProductsList/ProductsList.js
```

